### PR TITLE
Fail action if gsutil rsync command fail

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,8 @@ rm /secrets.json
 # Sync files to bucket
 echo "Syncing bucket $BUCKET ..."
 gsutil -m rsync -r -c -d -x "$INPUT_EXCLUDE" /github/workspace gs://$INPUT_BUCKET/
+if [ $? -ne 0 ]; then
+    echo "Syncing failed"
+    exit 1
+fi
 echo "Done."


### PR DESCRIPTION
If there is a failure in syncing the bucket action will still succeed e.g.:
```
Syncing bucket  ...
Building synchronization state...
Caught non-retryable exception while listing gs://random-not-existing-bucket/: BucketNotFoundException: 404 gs://random-not-existing-bucket bucket does not exist.
CommandException: Caught non-retryable exception - aborting rsync
Done
```
Added check for the status returned to make sure that action is successful only if rsync command succeeded