### PR TITLE
Add `sync_dir` input to enable sync specified directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _\*If you want to sync to an exiting bucket, make sure that your repository incl
 ## Inputs
 - `secrets` Your Google service account credentials as json. _**(Required)**_
 - `bucket` Name of the target bucket. _**(Required)**_
+- `sync_dir` Directory path to sync, relative to bucket, for example, `my_folder/to_sync`. It is empty by default.
 - `exclude` Regex for excluding files/dirs. ([gsutil rsync doc](https://cloud.google.com/storage/docs/gsutil/commands/rsync))
 
 ## Example
@@ -40,7 +41,8 @@ jobs:
         with:
           secrets: ${{ secrets.google_service_account_credentials }}
           bucket: 'patrickwyler.com'
-          exclude: '.*\.md$|.gitignore$|.git\/.*$|.github\/.*$'
+          exclude: '.*\.md$|\.gitignore$|\.git/.*$|\.github/.*$'
+
 ```
 
 ## Diagram

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
   bucket:
     description: Bucket name
     required: true
+  sync_dir:
+    description: Directory path to sync
+    required: false
+    default: ''
   exclude:
     description: Regex for excluding files/dirs
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ rm /secrets.json
 
 # Sync files to bucket
 echo "Syncing bucket $BUCKET ..."
-gsutil -m rsync -r -c -d -x "$INPUT_EXCLUDE" /github/workspace/$INPUT_SOURCE_DIR gs://$INPUT_BUCKET/
+gsutil -m rsync -r -c -d -x "$INPUT_EXCLUDE" /github/workspace/$INPUT_SYNC_DIR gs://$INPUT_BUCKET/$INPUT_SYNC_DIR
 if [ $? -ne 0 ]; then
     echo "Syncing failed"
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ rm /secrets.json
 
 # Sync files to bucket
 echo "Syncing bucket $BUCKET ..."
-gsutil -m rsync -r -c -d -x "$INPUT_EXCLUDE" /github/workspace gs://$INPUT_BUCKET/
+gsutil -m rsync -r -c -d -x "$INPUT_EXCLUDE" /github/workspace/$INPUT_SOURCE_DIR gs://$INPUT_BUCKET/
 if [ $? -ne 0 ]; then
     echo "Syncing failed"
     exit 1


### PR DESCRIPTION
This PR is to add a new optional input `sync_dir`, which will make it possible to only sync the specified directory. It is empty by default, which means to sync the whole bucket.