### PR TITLE
update sync_dir inputs, specify a distinct repository and bucket directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # GCS Bucket Sync Action
+
 This action helps by easily syncing a Github repository with a Google Cloud Storage bucket. It is very generic and can be used for different purposes. I used it for uploading my static website.
 
 ## Features
-- [X] Sync files/directories from your repository to your bucket
-- [X] Delete files/directories from your bucket which where removed in your repository
-- [X] Exclude certain files from being synced with the bucket
+
+- [x] Sync files/directories from your repository to your bucket
+- [x] Delete files/directories from your bucket which where removed in your repository
+- [x] Exclude certain files from being synced with the bucket
 
 ## Requirements
-- An existing empty* bucket
+
+- An existing empty\* bucket
 - A service account with access to the bucket
 - The service account key _(json format)_
 
 _\*If you want to sync to an existing bucket, make sure that your repository includes the whole content of it, otherwise you will lose data!_
 
 ## Inputs
+
 - `secrets` Your Google service account credentials as json. _**(Required)**_
 - `bucket` Name of the target bucket. _**(Required)**_
-- `sync_dir` Directory path to sync, relative to bucket, for example, `my_folder/to_sync`. It is empty by default.
+- `sync_dir_from` Repository directory path to sync, for example, `my_folder/to_sync`. It is empty by default.
+- `sync_dir_to` Bucket directory path to sync to, for example, `my_folder/to_sync`. It is empty by default.
 - `exclude` Regex for excluding files/dirs. ([gsutil rsync doc](https://cloud.google.com/storage/docs/gsutil/commands/rsync))
 
 ## Example
@@ -50,4 +55,5 @@ jobs:
 ![Diagram](http://www.plantuml.com/plantuml/png/TPB1JiCm38RlUGghNE3GmUWa149eOqoSk8mhbopnscXfKYMfs8JsxgInjcwZ71fPzcVd_-DEVU0kjBLcVgDCmnslmQ48t9GQuOS1hAoJwEPMMmVoeU2JnsFoC-mY9BclKB8zOqBRLaAfGjMkW7l8tbEOfJbhgsCBE6nigYrZu5MmRfV1rNUb0brt1ALoumIEui28hDTIuDq5KH11Lrv0IcCwY5akPcyVYr4j_w4cnqcgDDPXZoMkVnEFEiRAcjG0PEvSrNqggPgNw3EgzXUDgMWaRaTLgFKVWBhHEUjEW3thldW8MpVMe0d0IKR_q31B6P9U5ASx4GrnrdOUvbtoR2shLcmm9EOrXSDB8Mp88kcd-f3D0MZOwhvJpVfNVixpWzCdo4eCQOY_ZI8yV9bhXxw9AE1Mw5PYJ47wZMzYb37gX3n_ELYCGoBYTqOaO8f6jhN-1G00)
 
 ### Tags
+
 GCP, Google Cloud Platform, GCS, Google Cloud Storage, Bucket, Sync, Syncing, Uploading, Upload

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
-name: 'Google Cloud Storage Bucket Sync (GCP,GCS)'
-description: 'Sync a Github repository with a Google Cloud Storage (GCS) bucket'
-author: 'Patrick Wyler'
+name: "Google Cloud Storage Bucket Sync (GCP,GCS)"
+description: "Sync a Github repository with a Google Cloud Storage (GCS) bucket"
+author: "Patrick Wyler"
 
 inputs:
   secrets:
@@ -9,14 +9,18 @@ inputs:
   bucket:
     description: Bucket name
     required: true
-  sync_dir:
-    description: Directory path to sync
+  sync_dir_from:
+    description: Repository Directory path to sync
     required: false
-    default: ''
+    default: ""
+  sync_dir_to:
+    description: Bucket Directory path to sync to
+    required: false
+    default: ""
   exclude:
     description: Regex for excluding files/dirs
     required: false
-    default: '.git$'
+    default: ".git$"
 
 runs:
   using: docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,9 @@ rm /secrets.json
 
 # Sync files to bucket
 echo "Syncing bucket $BUCKET ..."
-gsutil -m rsync -r -c -d -x "$INPUT_EXCLUDE" /github/workspace/$INPUT_SYNC_DIR gs://$INPUT_BUCKET/$INPUT_SYNC_DIR
+gsutil -m rsync -r -c -d -x "$INPUT_EXCLUDE" /github/workspace/$INPUT_SYNC_DIR_FROM gs://$INPUT_BUCKET/$INPUT_SYNC_DIR_TO
 if [ $? -ne 0 ]; then
     echo "Syncing failed"
-    exit 1
+    exit 1 
 fi
 echo "Done."


### PR DESCRIPTION
A pull request to allow people to set a target repository in the bucket that's different from repository directory