### PR TITLE
Proposed update to gcloud storage tool with cache_control and additional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This action helps by easily syncing a Github repository with a Google Cloud Stor
 - [x] Sync files/directories from your repository to your bucket
 - [x] Delete files/directories from your bucket which where removed in your repository
 - [x] Exclude certain files from being synced with the bucket
+- [x] Include optional metadata tags for fine-grained control over file behaviors
 
 ## Requirements
 
@@ -22,7 +23,10 @@ _\*If you want to sync to an existing bucket, make sure that your repository inc
 - `bucket` Name of the target bucket. _**(Required)**_
 - `sync_dir_from` Repository directory path to sync, for example, `my_folder/to_sync`. It is empty by default.
 - `sync_dir_to` Bucket directory path to sync to, for example, `my_folder/to_sync`. It is empty by default.
-- `exclude` Regex for excluding files/dirs. ([gsutil rsync doc](https://cloud.google.com/storage/docs/gsutil/commands/rsync))
+- `exclude` Regex for excluding files/dirs.
+- `cache_control` cache control metadata tag, to control caching of content
+- `addtl_tags` any additional tags you want to include (see https://cloud.google.com/sdk/gcloud/reference/storage/rsync for docs and tag reference)
+  
 
 ## Example
 
@@ -47,6 +51,7 @@ jobs:
           secrets: ${{ secrets.google_service_account_credentials }}
           bucket: 'patrickwyler.com'
           exclude: '.*\.md$|\.gitignore$|\.git/.*$|\.github/.*$'
+          cache_control: 'no-cache'
 
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,14 @@ inputs:
     description: Regex for excluding files/dirs
     required: false
     default: ".git$"
+  cache_control:
+    description: Cache-Control header value
+    required: false
+    default: ""
+  addtl_tags:
+    description: Additional tags to add to the sync
+    required: false
+    default: ""
 
 runs:
   using: docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ rm /secrets.json
 
 # Sync files to bucket
 echo "Syncing bucket $BUCKET ..."
-gsutil -m rsync -r -c -d -x "$INPUT_EXCLUDE" /github/workspace/$INPUT_SYNC_DIR_FROM gs://$INPUT_BUCKET/$INPUT_SYNC_DIR_TO
+gcloud storage rsync /github/workspace/$INPUT_SYNC_DIR_FROM gs://$INPUT_BUCKET/$INPUT_SYNC_DIR_TO --recursive --checksums-only --delete-unmatched-destination-objects --cache-control="$INPUT_CACHE_CONTROL" --exclude="$INPUT_EXCLUDE" $INPUT_ADDTL_TAGS
 if [ $? -ne 0 ]; then
     echo "Syncing failed"
     exit 1 


### PR DESCRIPTION
Proposing to update the gsutil rsync tool to the [gcloud storage rsync tool](https://cloud.google.com/sdk/gcloud/reference/storage/rsync) for greater flexibility of metadata tags. I've done a translation of syntax based on the equivalent commands in the docs.

For my use case, I have been hosting a publicly accessible static website using google storage, and rapidly updating it as a preview during development. Google cloud by default sets cache-control on public buckets to 1 hour, so I have to either manually clear the cache or wait 1 hour to see the changes in the bucket. The gsync utility erases the cache-control metadata tag whenever it syncs files.

If I can use the gcloud storage utility to run the sync actions on push, I can programmatically control the metadata tags I want to include as well.

I'm new to working with GCP storage programmatically, so let me know if I'm missing anything here and there is a simpler path to the intended outcome.